### PR TITLE
Task-3. New API_PATH for Products service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React-shop-cloudfront
 
-- CloudFront URL: https://d2ijnvh7tq4ic6.cloudfront.net
-- S3 Bucket URL (returns 403): https://infrastructurestack-xxxxxxxxxxxxxxxx2a22bac2-gcbo2zfansmk.s3.eu-north-1.amazonaws.com
+- CloudFront URL: [https://d1rnsh23r9ia7o.cloudfront.net](https://d1rnsh23r9ia7o.cloudfront.net)
+- S3 Bucket URL (returns 403): [https://awsdevcoursefrontendstack-awsdevcoursefrontendbuck-zahpmkwqvkey.s3.eu-north-1.amazonaws.com](https://awsdevcoursefrontendstack-awsdevcoursefrontendbuck-zahpmkwqvkey.s3.eu-north-1.amazonaws.com)
 
 
 This is frontend starter project for nodejs-aws mentoring program. It uses the following technologies:

--- a/infrastructure/bin/infrastructure.js
+++ b/infrastructure/bin/infrastructure.js
@@ -4,7 +4,7 @@ const cdk = require('aws-cdk-lib');
 const { InfrastructureStack } = require('../lib/infrastructure-stack');
 
 const app = new cdk.App();
-new InfrastructureStack(app, 'InfrastructureStack', {
+new InfrastructureStack(app, 'AWSDevCourseFrontendStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/infrastructure/lib/infrastructure-stack.js
+++ b/infrastructure/lib/infrastructure-stack.js
@@ -9,13 +9,13 @@ class InfrastructureStack extends Stack {
   constructor(scope, id, props) {
     super(scope, id, props);
 
-    const websiteBucket = new Bucket(this, 'XXXXXXXXXXXXXXXX', {
+    const websiteBucket = new Bucket(this, 'AWSDevCourseFrontendBucket', {
       accessControl: BucketAccessControl.PRIVATE,
       enforceSSL: true,
       versioned: true,
     });
 
-    const distribution = new Distribution(this, 'Distribution', {
+    const distribution = new Distribution(this, 'AWSDevCourseFrontendDistribution', {
       defaultBehavior: {
         origin: S3BucketOrigin.withOriginAccessControl(websiteBucket),
         viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -30,7 +30,7 @@ class InfrastructureStack extends Stack {
       ],
     });
 
-    new BucketDeployment(this, 'S3BucketForRSSchoolTaskXXX', {
+    new BucketDeployment(this, 'AWSDevCourseFrontendBucketDeployment', {
       sources: [Source.asset(path.join(__dirname, '../../dist'))],
       destinationBucket: websiteBucket,
       distribution,

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,5 +1,5 @@
 const API_PATHS = {
-  product: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  product: "https://zzdhws7qx3.execute-api.eu-north-1.amazonaws.com/prod",
   order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -9,7 +9,7 @@ export function useAvailableProducts() {
     "available-products",
     async () => {
       const res = await axios.get<AvailableProduct[]>(
-        `${API_PATHS.bff}/product/available`
+        `${API_PATHS.product}/products`
       );
       return res.data;
     }
@@ -29,7 +29,7 @@ export function useAvailableProduct(id?: string) {
     ["product", { id }],
     async () => {
       const res = await axios.get<AvailableProduct>(
-        `${API_PATHS.bff}/product/${id}`
+        `${API_PATHS.product}/products/${id}`
       );
       return res.data;
     },


### PR DESCRIPTION
# Task-3 for AWS developer course

Updated API_PATHS for Product dervice.
Assets also updated in S3 Bucket. 

Also updated infrastructure from task-2 (to avoid the same names for infrastructure stacks).

CloudFront URL (with working products): [https://d1rnsh23r9ia7o.cloudfront.net/](https://d1rnsh23r9ia7o.cloudfront.net/)